### PR TITLE
Add support for enum to Utils::stringifyValue in order to support enum as default value of class property

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,11 @@
             "Murtukov\\PHPCodeGenerator\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
     "require-dev": {
         "phpstan/phpstan": "^1.12.4",
         "phpunit/phpunit": "^10",

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -96,6 +96,10 @@ class Utils
 
             case 'object':
                 if (!$value instanceof GeneratorInterface) {
+                    if (enum_exists($value::class)) {
+                        return '\\'.$value::class.'::'.$value->name;
+                    }
+
                     try {
                         $result = json_encode($value->__toString());
 

--- a/tests/Fixtures/BasicEnum.php
+++ b/tests/Fixtures/BasicEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tests\Fixtures;
+
+enum BasicEnum
+{
+    case ONE;
+    case TWO;
+}

--- a/tests/Fixtures/StringBackedEnum.php
+++ b/tests/Fixtures/StringBackedEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tests\Fixtures;
+
+enum StringBackedEnum: string
+{
+    case ONE = 'one';
+    case TWO = 'two';
+}

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Murtukov\PHPCodeGenerator\Utils;
 use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\BasicEnum;
+use Tests\Fixtures\StringBackedEnum;
 
 class UtilsTest extends TestCase
 {
@@ -24,6 +26,22 @@ class UtilsTest extends TestCase
         $this->expectException(Exception::class);
 
         Utils::stringify(new stdClass());
+    }
+
+    /**
+     * @test
+     */
+    public function stringifyEnum(): void
+    {
+        $this->assertEquals('\\Tests\\Fixtures\\BasicEnum::ONE', Utils::stringify(BasicEnum::ONE));
+    }
+
+    /**
+     * @test
+     */
+    public function stringifyBackedEnum(): void
+    {
+        $this->assertEquals('\\Tests\\Fixtures\\StringBackedEnum::ONE', Utils::stringify(StringBackedEnum::ONE));
     }
 
     /**


### PR DESCRIPTION
(Sorry for explaining the PR by example with another project but I do not use `php-code-generator` directly.)
**EDIT:** Check my comment https://github.com/murtukov/php-code-generator/pull/21#issuecomment-2473881537 below for much simpler example.

I am using `graphql:compile` command from `overblog/graphql-bundle` (https://github.com/overblog/GraphQLBundle/blob/master/docs/index.md) which internally uses `php-code-generator`.

When I ran `composer graphql:compile` I got the following error:
```                                                                                    
[Exception]                                                                       
Cannot stringify object of class: 'FrontBundle\Enum\Profile\ProfileOutlinkType'.  

Exception trace:
  at vendor/murtukov/php-code-generator/src/Utils.php:113
  ...
  Murtukov\PHPCodeGenerator\PhpFile->save() at vendor/overblog/graphql-bundle/src/Generator/TypeGenerator.php:93
```

I had GraphQL types defined as follows:
```php
namespace MyApp;

use Overblog\GraphQLBundle\Annotation as GQL;

/**
 * @GQL\Enum(name="LinkType")
 */
enum LinkType: string 
{
    case INSTAGRAM = 'instagram';
    case YOUTUBE = 'youtube';
}

/**
 * @GQL\Input(name="LinkData")
 */
class LinkData
{
    /**
     * @GQL\Field(type="LinkType!")
     */
    public LinkType $type = LinkType::INSTAGRAM;
    public string $url = '';
}
```

The [CompileCommand](https://github.com/overblog/GraphQLBundle/blob/master/src/Command/CompileCommand.php) tried to generate a PHP file that looks like this:
```php
<?php

namespace Project\Generated\__DEFINITIONS__;

use GraphQL\Type\Definition\InputObjectType;
use GraphQL\Type\Definition\Type;
use Overblog\GraphQLBundle\Definition\ConfigProcessor;
use Overblog\GraphQLBundle\Definition\GraphQLServices;
use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
use Overblog\GraphQLBundle\Definition\Type\GeneratedTypeInterface;

/**
 * THIS FILE WAS GENERATED AND SHOULD NOT BE EDITED MANUALLY.
 */
final class LinkDataType extends InputObjectType implements GeneratedTypeInterface, AliasedInterface
{
    public const NAME = 'LinkData';
    
    public function __construct(ConfigProcessor $configProcessor, GraphQLServices $services)
    {
        $config = [
            'name' => self::NAME,
            'fields' => fn() => [
                'type' => [
                    'type' => fn() => Type::nonNull($services->getType('LinkType')),
                    'defaultValue' => \MyApp\LinkType::INSTAGRAM,
                ],
                'url' => [
                    'type' => Type::nonNull(Type::string()),
                    'defaultValue' => '',
                ],
            ],
        ];
        
        parent::__construct($configProcessor->process($config));
    }
    
    /**
     * {@inheritdoc}
     */
    public static function getAliases(): array
    {
        return [self::NAME];
    }
}
```

however, without the changes in this PR it was failing when generating the line:
```
'defaultValue' => \MyApp\LinkType::INSTAGRAM,
```
because `\Murtukov\PHPCodeGenerator\Utils::stringifyValue` was trying to call `__toString` method on the enum instance `\MyApp\LinkType::INSTAGRAM` which is not possible because enums do not have (and [cannot have](https://github.com/php/php-src/blob/80197c59ec9cb3c152df7a11432ad4b790f61f5b/Zend/zend_enum.c#L86)) `__toString` method.

I realized that when calling `stringifyValue` with enum instance, we can simply return a fully-qualified reference to the enum value itself. So that is exactly what this PR does.

### Note
I was also thinking about returning the string value of the enum, but:
1. this approach would only work with [backed enums](https://www.php.net/manual/en/language.enumerations.backed.php) and not [basic enums](https://www.php.net/manual/en/language.enumerations.basics.php).
2. [`graphql:dump-schema`](https://github.com/overblog/GraphQLBundle/blob/master/src/Command/GraphQLDumpSchemaCommand.php) command was throwing this error:
```
[GraphQL\Error\SerializationError]                                                                              
Cannot serialize value "instagram" as it must be an instance of enum MyApp\LinkType. 

Exception trace:
  at vendor/overblog/graphql-bundle/src/Definition/Type/PhpEnumType.php:117
```